### PR TITLE
feat: add flags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,12 @@ require (
 	google.golang.org/protobuf v1.31.0
 )
 
-require github.com/google/gofuzz v1.2.0 // indirect
+require (
+	github.com/google/gofuzz v1.2.0 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/cobra v1.7.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+)
 
 require (
 	github.com/0xPolygonHermez/zkevm-node v0.2.2

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	github.com/0xPolygon/polygon-edge v1.1.0
 	github.com/rs/zerolog v1.29.1
+	github.com/spf13/cobra v1.7.0
 	google.golang.org/grpc v1.57.0
 	google.golang.org/protobuf v1.31.0
 )
@@ -12,7 +13,6 @@ require (
 require (
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,7 @@ github.com/0xPolygon/polygon-edge v1.1.0/go.mod h1:ad7LJSLlvY5xchl2GVnlojh8O1faY
 github.com/0xPolygonHermez/zkevm-node v0.2.2 h1:/fLQWxYSXU35fSBrNPqrVNVUX3WNEzDIcn6o6UYg40g=
 github.com/0xPolygonHermez/zkevm-node v0.2.2/go.mod h1:fGAoEyEiAsAOHNvTjTk+06Zc1zBrFQ1TalYzkfx4yKM=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
+github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
@@ -12,6 +13,8 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
@@ -24,6 +27,11 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.29.1 h1:cO+d60CHkknCbvzEWxP0S9K6KqyTjrCNUy1LdQLCGPc=
 github.com/rs/zerolog v1.29.1/go.mod h1:Le6ESbR7hc+DP6Lt1THiV8CQSdkkNrd3R0XbEgp3ZBU=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
+github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/umbracle/fastrlp v0.1.1-0.20230504065717-58a1b8a9929d h1:HAg1Kpr9buwRxEiC2UXU9oT2AU8uCU7o3/WTH+Lt5wo=
 github.com/umbracle/fastrlp v0.1.1-0.20230504065717-58a1b8a9929d/go.mod h1:5RHgqiFjd4vLJESMWagP/E7su+5Gzk0iqqmrotR8WdA=
@@ -48,4 +56,6 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=
 google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/grpc/grpc.go
+++ b/grpc/grpc.go
@@ -21,10 +21,9 @@ import (
 
 const (
 	// Mock data file paths.
-	InputDataDir = "data"
-	StatusFile   = "status.json"
-	BlocksFile   = "block.json"
-	TraceFile    = "trace.json"
+	StatusFile = "status.json"
+	BlocksFile = "block.json"
+	TraceFile  = "trace.json"
 
 	// Constant block height returned by the `/GetStatus` endpoint.
 	constantBlockHeight = 100_000_000_000_000_000
@@ -39,6 +38,7 @@ var (
 	counterStep int = 50
 
 	// Mock data provided by the user.
+	mockDir        string
 	mockStatusData *pb.StatusResponse
 	mockBlockData  *pb.BlockResponse
 	mockTraceData  *pb.TraceResponse
@@ -52,7 +52,7 @@ type server struct {
 // StartgRPCServer starts a gRPC server on the specified port.
 // It listens for incoming TCP connections and handles gRPC requests using the internal server
 // implementation. The server continues to run until it is manually stopped or an error occurs.
-func StartgRPCServer(port int) error {
+func StartgRPCServer(port int, mockDataDir string) error {
 	// Set up the logger.
 	lc := logger.LoggerConfig{
 		Level:       zerolog.InfoLevel,
@@ -72,6 +72,8 @@ func StartgRPCServer(port int) error {
 	pb.RegisterSystemServer(s, &server{})
 
 	// Load mock data if provided.
+	log.Info().Msgf("Fetching mock data from `%s` directory", mockDataDir)
+	mockDir = mockDataDir
 	mockStatusData, mockBlockData, mockTraceData, err = loadMockData()
 	if err != nil {
 		log.Error().Err(err).Msg("Unable to load mock data")
@@ -91,7 +93,7 @@ func StartgRPCServer(port int) error {
 func loadMockData() (*pb.StatusResponse, *pb.BlockResponse, *pb.TraceResponse, error) {
 	// Load status mock data.
 	var mockStatus pb.StatusResponse
-	statusMockFilePath := fmt.Sprintf("%s/%s", InputDataDir, StatusFile)
+	statusMockFilePath := fmt.Sprintf("%s/%s", mockDir, StatusFile)
 	if _, err := os.Stat(statusMockFilePath); err == nil {
 		data, err := os.ReadFile(statusMockFilePath)
 		if err != nil {
@@ -108,7 +110,7 @@ func loadMockData() (*pb.StatusResponse, *pb.BlockResponse, *pb.TraceResponse, e
 
 	// Load block mock data.
 	var mockBlock pb.BlockResponse
-	blocksMockFilePath := fmt.Sprintf("%s/%s", InputDataDir, BlocksFile)
+	blocksMockFilePath := fmt.Sprintf("%s/%s", mockDir, BlocksFile)
 	if _, err := os.Stat(blocksMockFilePath); err == nil {
 		data, err := os.ReadFile(blocksMockFilePath)
 		if err != nil {
@@ -125,7 +127,7 @@ func loadMockData() (*pb.StatusResponse, *pb.BlockResponse, *pb.TraceResponse, e
 
 	// Load trace mock data.
 	var mockTrace pb.TraceResponse
-	tracesMockFilePath := fmt.Sprintf("%s/%s", InputDataDir, TraceFile)
+	tracesMockFilePath := fmt.Sprintf("%s/%s", mockDir, TraceFile)
 	if _, err := os.Stat(tracesMockFilePath); err == nil {
 		data, err := os.ReadFile(tracesMockFilePath)
 		if err != nil {

--- a/grpc/grpc.go
+++ b/grpc/grpc.go
@@ -25,7 +25,7 @@ const (
 	BlocksFile = "block.json"
 	TraceFile  = "trace.json"
 
-	// Constant block height returned by the `/GetStatus` endpoint.
+	// Constant dummy block height returned by the `/GetStatus` endpoint.
 	constantBlockHeight = 100_000_000_000_000_000
 )
 

--- a/grpc/grpc.go
+++ b/grpc/grpc.go
@@ -52,10 +52,10 @@ type server struct {
 // StartgRPCServer starts a gRPC server on the specified port.
 // It listens for incoming TCP connections and handles gRPC requests using the internal server
 // implementation. The server continues to run until it is manually stopped or an error occurs.
-func StartgRPCServer(port int, mockDataDir string) error {
+func StartgRPCServer(logLevel zerolog.Level, port int, mockDataDir string) error {
 	// Set up the logger.
 	lc := logger.LoggerConfig{
-		Level:       zerolog.InfoLevel,
+		Level:       logLevel,
 		CallerField: "grpc-server",
 	}
 	log = logger.NewLogger(lc)

--- a/http/http.go
+++ b/http/http.go
@@ -11,12 +11,12 @@ import (
 	"github.com/rs/zerolog"
 )
 
-// saveEndpoint is the URL path for the save endpoint.
-const saveEndpoint = "/save"
-
 var (
 	// log is the package-level variable used for logging messages and errors.
 	log zerolog.Logger
+
+	// saveEndpoint is the URL path for the save endpoint.
+	saveEndpoint string
 
 	// proofsDir is the repository in which proofs are saved to the disk.
 	proofsDir string
@@ -28,7 +28,7 @@ var (
 // StartHTTPServer starts an HTTP server on the specified port and sets up the necessary endpoints.
 // The server listens for incoming requests and handles them accordingly.
 // The `/save` endpoint allows clients to save data to a file in the specified output directory.
-func StartHTTPServer(port int, outputDir string) error {
+func StartHTTPServer(port int, _saveEndpoint string, outputDir string) error {
 	// Set up the logger.
 	lc := logger.LoggerConfig{
 		Level:       zerolog.InfoLevel,
@@ -52,8 +52,10 @@ func StartHTTPServer(port int, outputDir string) error {
 	proofsDir = outputDir
 
 	// Start the HTTP server.
-	log.Info().Msgf("HTTP server is starting on port %d", port)
+	saveEndpoint = _saveEndpoint
 	http.HandleFunc(saveEndpoint, saveHandler)
+	log.Info().Msgf("HTTP server save endpoint: %s ready", saveEndpoint)
+	log.Info().Msgf("HTTP server is starting on port %d", port)
 	if err := http.ListenAndServe(fmt.Sprintf(":%d", port), nil); err != nil {
 		log.Error().Err(err).Msg("Unable to start the HTTP server")
 		return err

--- a/http/http.go
+++ b/http/http.go
@@ -39,8 +39,7 @@ func StartHTTPServer(logLevel zerolog.Level, port int, _saveEndpoint string, out
 	// Create the proofs directory if it doesn't exist.
 	if _, err := os.Stat(outputDir); err != nil {
 		if os.IsNotExist(err) {
-			err := os.Mkdir(outputDir, 0755)
-			if err != nil {
+			if err = os.Mkdir(outputDir, 0755); err != nil {
 				log.Error().Err(err).Msg("Unable to create the proofs directory")
 				return err
 			}

--- a/http/http.go
+++ b/http/http.go
@@ -28,10 +28,10 @@ var (
 // StartHTTPServer starts an HTTP server on the specified port and sets up the necessary endpoints.
 // The server listens for incoming requests and handles them accordingly.
 // The `/save` endpoint allows clients to save data to a file in the specified output directory.
-func StartHTTPServer(port int, _saveEndpoint string, outputDir string) error {
+func StartHTTPServer(logLevel zerolog.Level, port int, _saveEndpoint string, outputDir string) error {
 	// Set up the logger.
 	lc := logger.LoggerConfig{
-		Level:       zerolog.InfoLevel,
+		Level:       logLevel,
 		CallerField: "http",
 	}
 	log = logger.NewLogger(lc)

--- a/http/http.go
+++ b/http/http.go
@@ -36,11 +36,18 @@ func StartHTTPServer(port int, outputDir string) error {
 	}
 	log = logger.NewLogger(lc)
 
-	// Create proof directory.
-	err := os.Mkdir(outputDir, 0755)
-	if err != nil {
-		log.Error().Err(err).Msg("Unable to create the proofs directory")
-		return err
+	// Create the proofs directory if it doesn't exist.
+	if _, err := os.Stat(outputDir); err != nil {
+		if os.IsNotExist(err) {
+			err := os.Mkdir(outputDir, 0755)
+			if err != nil {
+				log.Error().Err(err).Msg("Unable to create the proofs directory")
+				return err
+			}
+		} else {
+			log.Error().Err(err).Msg("Unable to check if the proofs directory exists")
+			return err
+		}
 	}
 	proofsDir = outputDir
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -23,7 +23,7 @@ func NewLogger(config LoggerConfig) zerolog.Logger {
 		TimeFormat: time.UnixDate,
 	}
 	return zerolog.New(output).
-		Level(zerolog.InfoLevel).
+		Level(config.Level).
 		With().
 		Caller().
 		Timestamp().

--- a/main.go
+++ b/main.go
@@ -4,20 +4,37 @@ import (
 	"log"
 	"zero-provers/server/grpc"
 	"zero-provers/server/http"
+
+	"github.com/spf13/cobra"
 )
 
-const (
-	gRPCServerPort  = 8546
-	HTTPServerPort  = 8080
-	ProofsOutputDir = "out"
-)
+type Config struct {
+	GRPCServerPort  int
+	HTTPServerPort  int
+	ProofsOutputDir string
+}
 
 func main() {
-	// Start the gRPC server.
-	go func() {
-		log.Fatal(grpc.StartgRPCServer(gRPCServerPort), nil)
-	}()
+	var config Config
+	var rootCmd = &cobra.Command{
+		Use:   "mock",
+		Short: "Edge gRPC mock server",
+		Run: func(cmd *cobra.Command, args []string) {
+			// Start the gRPC server.
+			go func() {
+				log.Fatal(grpc.StartgRPCServer(config.GRPCServerPort))
+			}()
 
-	// Start the HTTP server.
-	log.Fatal(http.StartHTTPServer(HTTPServerPort, ProofsOutputDir), nil)
+			// Start the HTTP server.
+			log.Fatal(http.StartHTTPServer(config.HTTPServerPort, config.ProofsOutputDir))
+		},
+	}
+
+	// Define flags for configuration
+	rootCmd.Flags().IntVar(&config.GRPCServerPort, "grpc", 8546, "gRPC server port")
+	rootCmd.Flags().IntVar(&config.HTTPServerPort, "http", 8080, "HTTP server port")
+	rootCmd.Flags().StringVarP(&config.ProofsOutputDir, "output-dir", "o", "out", "Proofs output directory")
+	if err := rootCmd.Execute(); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ type Config struct {
 	GRPCServerPort  int
 	HTTPServerPort  int
 	ProofsOutputDir string
+	MockDataDir     string
 }
 
 func main() {
@@ -22,7 +23,7 @@ func main() {
 		Run: func(cmd *cobra.Command, args []string) {
 			// Start the gRPC server.
 			go func() {
-				log.Fatal(grpc.StartgRPCServer(config.GRPCServerPort))
+				log.Fatal(grpc.StartgRPCServer(config.GRPCServerPort, config.MockDataDir))
 			}()
 
 			// Start the HTTP server.
@@ -34,6 +35,7 @@ func main() {
 	rootCmd.Flags().IntVar(&config.GRPCServerPort, "grpc", 8546, "gRPC server port")
 	rootCmd.Flags().IntVar(&config.HTTPServerPort, "http", 8080, "HTTP server port")
 	rootCmd.Flags().StringVarP(&config.ProofsOutputDir, "output-dir", "o", "out", "Proofs output directory")
+	rootCmd.Flags().StringVarP(&config.MockDataDir, "mock-data-dir", "m", "data", "Mock data directory containing mock status (status.json), block (block.json) and trace (trace.json) files")
 	if err := rootCmd.Execute(); err != nil {
 		log.Fatal(err)
 	}

--- a/main.go
+++ b/main.go
@@ -9,10 +9,16 @@ import (
 )
 
 type Config struct {
-	GRPCServerPort  int
-	HTTPServerPort  int
+	// Port of the gRPC server.
+	GRPCServerPort int
+	// Port of the HTTP server.
+	HTTPServerPort int
+	// URL path of the HTTP server save endpoint.
+	HTTPServerSaveEndpoint string
+	// Directory in which proofs are stored.
 	ProofsOutputDir string
-	MockDataDir     string
+	// Directory in which mock data is provided.
+	MockDataDir string
 }
 
 func main() {
@@ -27,13 +33,14 @@ func main() {
 			}()
 
 			// Start the HTTP server.
-			log.Fatal(http.StartHTTPServer(config.HTTPServerPort, config.ProofsOutputDir))
+			log.Fatal(http.StartHTTPServer(config.HTTPServerPort, config.HTTPServerSaveEndpoint, config.ProofsOutputDir))
 		},
 	}
 
 	// Define flags for configuration
-	rootCmd.Flags().IntVar(&config.GRPCServerPort, "grpc", 8546, "gRPC server port")
-	rootCmd.Flags().IntVar(&config.HTTPServerPort, "http", 8080, "HTTP server port")
+	rootCmd.Flags().IntVarP(&config.GRPCServerPort, "grpc-port", "g", 8546, "gRPC server port")
+	rootCmd.Flags().IntVarP(&config.HTTPServerPort, "http-port", "p", 8080, "HTTP server port")
+	rootCmd.Flags().StringVarP(&config.HTTPServerSaveEndpoint, "http-save-endpoint", "e", "/save", "HTTP server save endpoint")
 	rootCmd.Flags().StringVarP(&config.ProofsOutputDir, "output-dir", "o", "out", "Proofs output directory")
 	rootCmd.Flags().StringVarP(&config.MockDataDir, "mock-data-dir", "m", "data", "Mock data directory containing mock status (status.json), block (block.json) and trace (trace.json) files")
 	if err := rootCmd.Execute(); err != nil {


### PR DESCRIPTION
Add a few flags to make it easier to use the mock server.

```sh
$ go run main.go --help
Edge gRPC mock server

Usage:
  mock [flags]

Flags:
  -d, --debug                       Enable verbose mode
  -g, --grpc-port int               gRPC server port (default 8546)
  -h, --help                        help for mock
  -p, --http-port int               HTTP server port (default 8080)
  -e, --http-save-endpoint string   HTTP server save endpoint (default "/save")
  -m, --mock-data-dir string        Mock data directory containing mock status (status.json), block (block.json) and trace (trace.json) files (default "data")
  -o, --output-dir string           Proofs output directory (default "out")
```

Resolves #1 
