### PR TITLE
fix: test script

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -4,19 +4,21 @@
 # Make sure the server is started!
 # go run main.go --http-port 8080 --http-save-endpoint /save --grpc-port 8546 --output-dir out
 
-while ! echo -n > 127.0.0.1:8546; do
-  echo "Mock server gRPC port is not open yet. Waiting for 5 seconds."
-  sleep 5
-done
-rm 127.0.0.1:8546
-echo "Mock server gRPC port is now open."
+wait_for_service() {
+  port=$1
+  name=$2
+  {
+    while ! echo -n > /dev/tcp/127.0.0.1/$port; do
+      echo "$name port is not open yet. Waiting for 5 seconds"
+      sleep 5
+    done
+  } 2>/dev/null
+  echo "$name port is now open."
+}
 
-while ! echo -n > 127.0.0.1:8080; do
-  echo "Mock server HTTP port is not open yet. Waiting for 5 seconds."
-  sleep 5
-done
-rm 127.0.0.1:8080
-echo "Mock server HTTP port is now open."
+echo "Waiting for services..."
+wait_for_service 8546 "gRPC"
+wait_for_service 8080 "HTTP"
 
 echo "Sending gRPC requests..."
 grpcurl -plaintext  127.0.0.1:8546 v1.System/GetStatus	


### PR DESCRIPTION
The script would fail if the gRPC and HTTP ports of the mock server were not ready. It's supposed to wait for the services to become ready instead of failing.