### PR TITLE
chore(ci): break down ci workflows into multiple files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,100 +15,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
-env:
-  GO_VERSION: "1.21"
-  # Check https://grpc.io/docs/languages/go/quickstart/ for `protoc` versions.
-  PROTOC_VERSION: "23.4"
-  PROTOC_GEN_GO_VERSION: "1.28"
-  PROTOC_GEN_GO_GRPC_VERSION: "1.2"
-
 jobs:
   lint:
-    name: lint
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v3
-      
-      - name: Install go
-        uses: actions/setup-go@v4
-        with:
-          go-version: ${{ env.GO_VERSION }}
-      
-      - name: Install golangci-lint
-        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
-      
-      - name: Install shadow
-        run: go install golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow@latest
+    uses: ./.github/workflows/lint.yml
 
-      - name: Run linters
-        run: make lint
-  
-  up-to-date:
-    name: up-to-date
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v3
-      
-      - name: Install protoc
-        run: |
-          wget https://github.com/protocolbuffers/protobuf/releases/download/v${{ env.PROTOC_VERSION }}/protoc-${{ env.PROTOC_VERSION }}-linux-x86_64.zip
-          unzip protoc-23.4-linux-x86_64.zip
-          sudo mv bin/protoc /usr/local/bin/
-          sudo mv include/google /usr/local/include
-          protoc --version
-      
-      - name: Install go
-        uses: actions/setup-go@v4
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
-      - name: Install protoc plugins for go
-        run: |
-          go install google.golang.org/protobuf/cmd/protoc-gen-go@v${{ env.PROTOC_GEN_GO_VERSION }}
-          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v${{ env.PROTOC_GEN_GO_GRPC_VERSION }}
-          protoc-gen-go --version
-          protoc-gen-go-grpc --version
-
-      - name: Generate code
-        run: make gen
-
-      - name: Check if code is up to date
-        run: |
-          git update-index --really-refresh
-          if $(git diff-index --quiet HEAD); then 
-            echo "✅ gRPC service is up to date."
-          else
-            echo "❌ Error: gRPC service is not up to date. Please run 'make gen' and commit your changes."
-            exit 1
-          fi
+  grpc-code-consistency:
+    uses: ./.github/workflows/grpc-code-consistency.yml
+    needs: lint
 
   test:
-    name: test
-    needs: [lint, up-to-date]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v3
-      
-      - name: Install go
-        uses: actions/setup-go@v4
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
-      - name: Build code
-        run: go build -o mock-server main.go
-      
-      - name: Install grpcurl
-        run: |
-          wget https://github.com/fullstorydev/grpcurl/releases/download/v1.8.7/grpcurl_1.8.7_linux_x86_64.tar.gz
-          tar -xvf grpcurl_1.8.7_linux_x86_64.tar.gz
-          sudo mv grpcurl /usr/local/bin/
-          sudo chmod +x /usr/local/bin/grpcurl
-          grpcurl --version
-
-      - name: Run tests
-        run: |
-          ./mock-server --http-port 8080 --http-save-endpoint /save --grpc-port 8546 --output-dir out &
-          make test
+    uses: ./.github/workflows/test.yml
+    needs:
+      - lint
+      - grpc-code-consistency

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ on:
       - 'data/**'
       - '.gitignore'
 
+env:
+  GO_VERSION: "1.21"
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -18,13 +21,19 @@ concurrency:
 jobs:
   lint:
     uses: ./.github/workflows/lint.yml
+    with:
+      go-version: ${{ env.GO_VERSION }}
 
   grpc-code-consistency:
-    uses: ./.github/workflows/grpc-code-consistency.yml
     needs: lint
+    uses: ./.github/workflows/grpc-code-consistency.yml
+    with:
+      go-version: ${{ env.GO_VERSION }}
 
   test:
-    uses: ./.github/workflows/test.yml
     needs:
       - lint
       - grpc-code-consistency
+    uses: ./.github/workflows/test.yml
+    with:
+      go-version: ${{ env.GO_VERSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,9 @@ name: ci
 
 on:
   push:
-    branches:
-      - "main"
+    branches: ['*']
   pull_request:
-    paths-ignore:
-      - 'README.md'
-      - 'Makefile'
-      - 'data/**'
-      - '.gitignore'
+    paths-ignore: ['README.md', 'Makefile', 'data/**', '.gitignore']
 
 env:
   GO_VERSION: "1.21"
@@ -31,9 +26,7 @@ jobs:
       go-version: ${{ env.GO_VERSION }}
 
   test:
-    needs:
-      - lint
-      - grpc-code-consistency
+    needs: [lint, grpc-code-consistency]
     uses: ./.github/workflows/test.yml
     with:
       go-version: ${{ env.GO_VERSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,12 @@ on:
   pull_request:
     paths-ignore: ['README.md', 'Makefile', 'data/**', '.gitignore']
 
-env:
-  GO_VERSION: "1.21"
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
+
+env:
+  GO_VERSION: "1.21"
 
 jobs:
   lint:

--- a/.github/workflows/grpc-code-consistency.yml
+++ b/.github/workflows/grpc-code-consistency.yml
@@ -1,13 +1,13 @@
 name: grpc-code-consistency
 
 on:
-  workflow_run:
-    workflows: ["ci"]
-    types:
-      - completed
+  workflow_call:
+    inputs:
+      go- :
+        required: true
+        type: string
 
 env:
-  GO_VERSION: "1.21"
   # Check https://grpc.io/docs/languages/go/quickstart/ for `protoc` versions.
   PROTOC_VERSION: "23.4"
   PROTOC_GEN_GO_VERSION: "1.28"
@@ -32,7 +32,7 @@ jobs:
       - name: Install go
         uses: actions/setup-go@v4
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version: ${{ inputs.go-version }}
 
       - name: Install protoc plugins for go
         run: |

--- a/.github/workflows/grpc-code-consistency.yml
+++ b/.github/workflows/grpc-code-consistency.yml
@@ -1,0 +1,55 @@
+name: grpc-code-consistency
+
+on:
+  workflow_run:
+    workflows: ["ci"]
+    types:
+      - completed
+
+env:
+  GO_VERSION: "1.21"
+  # Check https://grpc.io/docs/languages/go/quickstart/ for `protoc` versions.
+  PROTOC_VERSION: "23.4"
+  PROTOC_GEN_GO_VERSION: "1.28"
+  PROTOC_GEN_GO_GRPC_VERSION: "1.2"
+
+jobs:
+  grpc-code-consistency:
+    name: grpc-code-consistency
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+      
+      - name: Install protoc
+        run: |
+          wget https://github.com/protocolbuffers/protobuf/releases/download/v${{ env.PROTOC_VERSION }}/protoc-${{ env.PROTOC_VERSION }}-linux-x86_64.zip
+          unzip protoc-23.4-linux-x86_64.zip
+          sudo mv bin/protoc /usr/local/bin/
+          sudo mv include/google /usr/local/include
+          protoc --version
+      
+      - name: Install go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Install protoc plugins for go
+        run: |
+          go install google.golang.org/protobuf/cmd/protoc-gen-go@v${{ env.PROTOC_GEN_GO_VERSION }}
+          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v${{ env.PROTOC_GEN_GO_GRPC_VERSION }}
+          protoc-gen-go --version
+          protoc-gen-go-grpc --version
+
+      - name: Generate code
+        run: make gen
+
+      - name: Check if code is up to date
+        run: |
+          git update-index --really-refresh
+          if $(git diff-index --quiet HEAD); then 
+            echo "✅ gRPC service is up to date."
+          else
+            echo "❌ Error: gRPC service is not up to date. Please run 'make gen' and commit your changes."
+            exit 1
+          fi

--- a/.github/workflows/grpc-code-consistency.yml
+++ b/.github/workflows/grpc-code-consistency.yml
@@ -3,7 +3,7 @@ name: grpc-code-consistency
 on:
   workflow_call:
     inputs:
-      go- :
+      go-version:
         required: true
         type: string
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,13 +1,11 @@
 name: lint
 
 on:
-  workflow_run:
-    workflows: ["ci"]
-    types:
-      - completed
-
-env:
-  GO_VERSION: "1.21"
+  workflow_call:
+    inputs:
+      go- :
+        required: true
+        type: string
 
 jobs:
   lint:
@@ -20,7 +18,7 @@ jobs:
       - name: Install go
         uses: actions/setup-go@v4
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version: ${{ inputs.go-version }}
       
       - name: Install golangci-lint
         run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ name: lint
 on:
   workflow_call:
     inputs:
-      go- :
+      go-version:
         required: true
         type: string
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,32 @@
+name: lint
+
+on:
+  workflow_run:
+    workflows: ["ci"]
+    types:
+      - completed
+
+env:
+  GO_VERSION: "1.21"
+
+jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+      
+      - name: Install go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      
+      - name: Install golangci-lint
+        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
+      
+      - name: Install shadow
+        run: go install golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow@latest
+
+      - name: Run linters
+        run: make lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,39 @@
+name: test
+
+on:
+  workflow_run:
+    workflows: ["ci"]
+    types:
+      - completed
+
+env:
+  GO_VERSION: "1.21"
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+      
+      - name: Install go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Build code
+        run: go build -o mock-server main.go
+      
+      - name: Install grpcurl
+        run: |
+          wget https://github.com/fullstorydev/grpcurl/releases/download/v1.8.7/grpcurl_1.8.7_linux_x86_64.tar.gz
+          tar -xvf grpcurl_1.8.7_linux_x86_64.tar.gz
+          sudo mv grpcurl /usr/local/bin/
+          sudo chmod +x /usr/local/bin/grpcurl
+          grpcurl --version
+
+      - name: Run tests
+        run: |
+          ./mock-server --http-port 8080 --http-save-endpoint /save --grpc-port 8546 --output-dir out &
+          make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,13 +1,11 @@
 name: test
 
 on:
-  workflow_run:
-    workflows: ["ci"]
-    types:
-      - completed
-
-env:
-  GO_VERSION: "1.21"
+  workflow_call:
+    inputs:
+      go- :
+        required: true
+        type: string
 
 jobs:
   test:
@@ -20,7 +18,7 @@ jobs:
       - name: Install go
         uses: actions/setup-go@v4
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version: ${{ inputs.go-version }}
 
       - name: Build code
         run: go build -o mock-server main.go

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: test
 on:
   workflow_call:
     inputs:
-      go- :
+      go-version:
         required: true
         type: string
 


### PR DESCRIPTION
Break down the complexity of the actual CI workflow into smaller files where each file is responsible for one action such as `linting` or `testing`.