### PR TITLE
doc: add instructions to list all gRPC services

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,10 @@ gen: ## Compile protocol buffers and generate go code.
 clean: ## Delete generated go code.
 	rm -rf grpc/pb/*.go
 
+.PHONY: list
+list: ## List gRPC services (make sure gRPC server is listening on port 8546).
+	grpcurl -plaintext 127.0.0.1:8546 list v1.System
+
 ##@ Build
 
 .PHONY: build

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Simple mock of an [edge](https://github.com/0xPolygon/polygon-edge) gRPC server 
 
 It consists of two servers:
 
-1. A gRPC server that mocks the functioning of an Edge node. It only implements a subset of all the [methods](https://github.com/0xPolygon/polygon-edge/blob/zero-trace/server/proto/system.proto) such as `GetStatus`, `GetTrace` and `BlockByNumber`. By default, the data is mocked (see `data/`) but it can also be randomly generated using the `random` flag.
+1. A gRPC server that mocks the functioning of an Edge node. It only implements a subset of all the [methods](https://github.com/0xPolygon/polygon-edge/blob/zero-trace/server/proto/system.proto) such as `GetStatus`, `GetTrace` and `BlockByNumber`. You can get the list of available methods using `make list`. By default, the data is mocked (see `data/`) but it can also be randomly generated using the `random` flag.
 
 2. An HTTP server that either displays HTTP POST request data or saves it to the filesystem.
 


### PR DESCRIPTION
It uses [gRPC server reflection protocol](https://github.com/grpc/grpc/blob/master/doc/server-reflection.md).