### PR TITLE
fix: `dynamic` mode issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,8 @@ $ go run main.go \
   --update-data-threshold 30 \
   --output-dir out \
   --verbosity 0
-Thu Aug 24 18:53:26 CEST 2023 INF http/http.go:63 > HTTP server save endpoint: /save ready
-Thu Aug 24 18:53:26 CEST 2023 INF http/http.go:64 > HTTP server is starting on port 8080
-Thu Aug 24 18:53:26 CEST 2023 INF grpc/grpc.go:87 > gRPC server is starting on port 8546
+Thu Aug 24 18:53:26 CEST 2023 INF http/http.go:64 > HTTP server is listening on port 8080
+Thu Aug 24 18:53:26 CEST 2023 INF grpc/grpc.go:87 > gRPC server is listening on port 8546
 ```
 
 ### 2. Start the zero-prover setup

--- a/grpc/grpc.go
+++ b/grpc/grpc.go
@@ -85,6 +85,7 @@ func StartgRPCServer(_config ServerConfig) error {
 
 	// Start serving incoming gRPC requests on the listener.
 	log.Info().Msgf("gRPC server is starting on port %d", config.Port)
+	log.Debug().Msgf("Config: %+v", config)
 	if err := s.Serve(listener); err != nil {
 		log.Error().Err(err).Msg("Unable to start gRPC server")
 		return err

--- a/grpc/grpc.go
+++ b/grpc/grpc.go
@@ -84,7 +84,7 @@ func StartgRPCServer(_config ServerConfig) error {
 	pb.RegisterSystemServer(s, &server{})
 
 	// Start serving incoming gRPC requests on the listener.
-	log.Info().Msgf("gRPC server is starting on port %d", config.Port)
+	log.Info().Msgf("gRPC server is listening on port %d", config.Port)
 	log.Debug().Msgf("Config: %+v", config)
 	if err := s.Serve(listener); err != nil {
 		log.Error().Err(err).Msg("Unable to start gRPC server")

--- a/grpc/grpc.go
+++ b/grpc/grpc.go
@@ -279,7 +279,7 @@ func loadDataFromFile(filePath string, target interface{}) error {
 
 // Return file names in directory and sorted in natural order.
 func getFilesInDir(dirPath string) ([]string, error) {
-	files, err := filepath.Glob(filepath.Join(config.MockData.BlockDir, "*.json"))
+	files, err := filepath.Glob(filepath.Join(dirPath, "*.json"))
 	if err != nil {
 		return nil, err
 	}

--- a/grpc/grpc.go
+++ b/grpc/grpc.go
@@ -277,7 +277,7 @@ func loadDataFromFile(filePath string, target interface{}) error {
 // Load block number from block file.
 func getBlockNumberFromBlockFile(filePath string) (int64, error) {
 	var mockBlockRPC edge.BlockRPC
-	if err := loadDataFromFile(config.MockData.BlockFile, &mockBlockRPC); err != nil {
+	if err := loadDataFromFile(filePath, &mockBlockRPC); err != nil {
 		return 0, err
 	}
 	return int64(mockBlockRPC.Number), nil

--- a/grpc/grpc.go
+++ b/grpc/grpc.go
@@ -116,7 +116,7 @@ func (s *server) GetStatus(context.Context, *empty.Empty) (*pb.ChainStatus, erro
 
 	case modes.DynamicMode:
 		// List and sort the block mock files under the block mock directory.
-		files, err := getFilesInDir(filepath.Join(config.MockData.BlockDir, "*.json"))
+		files, err := getFilesInDir(config.MockData.BlockDir)
 		if err != nil {
 			return nil, err
 		}
@@ -163,7 +163,7 @@ func (s *server) BlockByNumber(context.Context, *pb.BlockNumber) (*pb.BlockData,
 
 	case modes.DynamicMode:
 		// List and sort the block mock files under the block mock directory.
-		files, err := getFilesInDir(filepath.Join(config.MockData.BlockDir, "*.json"))
+		files, err := getFilesInDir(config.MockData.BlockDir)
 		if err != nil {
 			return nil, err
 		}
@@ -219,7 +219,7 @@ func (s *server) GetTrace(context.Context, *pb.BlockNumber) (*pb.Trace, error) {
 
 	case modes.DynamicMode:
 		// List the block trace files under the trace mock directory.
-		files, err := getFilesInDir(filepath.Join(config.MockData.TraceDir, "*.json"))
+		files, err := getFilesInDir(config.MockData.TraceDir)
 		if err != nil {
 			return nil, err
 		}

--- a/http/http.go
+++ b/http/http.go
@@ -60,8 +60,8 @@ func StartHTTPServer(config ServerConfig) error {
 	// Start the HTTP server.
 	saveEndpoint = config.SaveEndpoint
 	http.HandleFunc(saveEndpoint, saveHandler)
-	log.Info().Msgf("HTTP server save endpoint: %s ready", saveEndpoint)
-	log.Info().Msgf("HTTP server is starting on port %d", config.Port)
+	log.Info().Msgf("HTTP server is listening on port %d", config.Port)
+	log.Debug().Msgf("Config: %+v", config)
 	if err := http.ListenAndServe(fmt.Sprintf(":%d", config.Port), nil); err != nil {
 		log.Error().Err(err).Msg("Unable to start the HTTP server")
 		return err


### PR DESCRIPTION
- Block numbers are loaded from file path instead of from config block mock file
- Mock files are sorted in natural order instead of alphabetical order (this prevent loading `trace_10.json` after `trace_1.json`)
- Display server config on startup (only in `debug` mode)
