### PR TITLE
feat: add `receipt` and other fields to random transaction traces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,16 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  # Package versions.
   GO_VERSION: "1.21"
   # Check https://grpc.io/docs/languages/go/quickstart/ for `protoc` versions.
   PROTOC_VERSION: "24.3"
   PROTOC_GEN_GO_VERSION: "1.28"
   PROTOC_GEN_GO_GRPC_VERSION: "1.2"
   ARCH: "linux-x86_64"
+
+  # Job config.
+  TEST_TIMEOUT_MINUTES: 4
 
 jobs:
   lint:
@@ -89,7 +93,7 @@ jobs:
     name: static-mode-test
     needs: [lint, grpc-code-is-up-to-date]
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: ${{ env.TEST_TIMEOUT_MINUTES }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -129,7 +133,7 @@ jobs:
     name: dynamic-mode-test
     needs: [lint, grpc-code-is-up-to-date]
     runs-on: ubuntu-latest
-    timeout-minutes: 4
+    timeout-minutes: ${{ env.TEST_TIMEOUT_MINUTES }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -170,7 +174,7 @@ jobs:
     name: random-mode-test
     needs: [lint, grpc-code-is-up-to-date]
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: ${{ env.TEST_TIMEOUT_MINUTES }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
     name: dynamic-mode-test
     needs: [lint, grpc-code-is-up-to-date]
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: 4
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -293,3 +293,24 @@ You can then run the server and experiment with it.
 Use `go run main.go --help` to list all the different flags available.
 
 Unit tests have not been implemented yet but you can run some HTTP/gRPC requests using [curl](https://curl.se/) and [grpcurl](https://github.com/fullstorydev/grpcurl) to test the behavior of the mock server. We provided a handy script called `scripts/test.sh` that you can execute using `make test` for this purpose.
+
+To integrate last changes from `polygon-edge@feat/zero` [branch](https://github.com/0xPolygon/polygon-edge/tree/feat/zero), copy the last commit you want to use (i.e. [9071047](https://github.com/0xPolygon/polygon-edge/commit/907104765c64fae5cf4f2a40a8561c7ff6184058)). Then modify the `replace` statement at the end of `go.mod`. It should look like the following.
+
+```diff
+diff --git a/go.mod b/go.mod
+index 183d3e7..c3731a8 100644
+--- a/go.mod
++++ b/go.mod
+@@ -34,4 +34,4 @@ require (
+
+ // Use polygon-edge@feat/zero last commit.
+ // https://github.com/0xPolygon/polygon-edge/tree/feat/zero
+-replace github.com/0xPolygon/polygon-edge => github.com/0xPolygon/polygon-edge v1.1.1-0.20230929152933-907104765c64
++replace github.com/0xPolygon/polygon-edge => github.com/0xPolygon/polygon-edge 9071047
+```
+
+Finally, simply run `go mod tidy`. It will automatically update dependencies and reformat the `go.mod` file.
+
+```go
+replace github.com/0xPolygon/polygon-edge => github.com/0xPolygon/polygon-edge v1.1.1-0.20230929152933-907104765c64
+```

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,4 @@ require (
 
 // Use polygon-edge@feat/zero last commit.
 // https://github.com/0xPolygon/polygon-edge/tree/feat/zero
-// 1. Add `replace github.com/0xPolygon/polygon-edge => github.com/0xPolygon/polygon-edge <commit_id>` to `go.mod`.
-// 2. Run `go mod tidy`, this will update `go.mod`.
 replace github.com/0xPolygon/polygon-edge => github.com/0xPolygon/polygon-edge v1.1.1-0.20230929152933-907104765c64


### PR DESCRIPTION
## Feature(s)

- Add `receipt`, `gasUsed` and `bloom` fields to `txnTraces`.

## Other

- Some random `uint64` values were hardcoded in `GenerateRandomEdgeBlock` and `generateRandomTx`. They are now generated randomly.
- Rename `generateRandomBytes` into `generateRandomByteSlice`
- Explain how to integrate last changes from `polygon-edge` in `README.md`.
- Double test jobs timeout (from 2 minutes to 4 minutes).